### PR TITLE
fix: use saved user parameters for generation

### DIFF
--- a/src/bot/commands/gen.ts
+++ b/src/bot/commands/gen.ts
@@ -32,11 +32,14 @@ composer.command('gen', async (ctx) => {
 
     await ctx.reply('🎨 Generating your image...');
 
-    const { imageUrl } = await GenerationService.generate(user.id, {
+    const { imageUrls } = await GenerationService.generate(user.id, {
       prompt,
     });
 
-    await ctx.replyWithPhoto(imageUrl);
+    // Send each generated image
+    for (const imageUrl of imageUrls) {
+      await ctx.replyWithPhoto(imageUrl);
+    }
   } catch (error: any) {
     const errorMessage = error.message || 'Unknown error';
     logger.error({ 

--- a/src/bot/commands/gen.ts
+++ b/src/bot/commands/gen.ts
@@ -32,14 +32,12 @@ composer.command('gen', async (ctx) => {
 
     await ctx.reply('🎨 Generating your image...');
 
-    const { imageUrls } = await GenerationService.generate(user.id, {
+    const { imageUrl, seed } = await GenerationService.generate(user.id, {
       prompt,
     });
 
-    // Send each generated image
-    for (const imageUrl of imageUrls) {
-      await ctx.replyWithPhoto(imageUrl);
-    }
+    await ctx.replyWithPhoto(imageUrl);
+    await ctx.reply(`🎲 Seed: ${seed}\nUse this seed to recreate the same image!`);
   } catch (error: any) {
     const errorMessage = error.message || 'Unknown error';
     logger.error({ 

--- a/src/bot/commands/gen.ts
+++ b/src/bot/commands/gen.ts
@@ -37,7 +37,7 @@ composer.command('gen', async (ctx) => {
     });
 
     await ctx.replyWithPhoto(imageUrl);
-    await ctx.reply(`🎲 Seed: ${seed}\nUse this seed to recreate the same image!`);
+    await ctx.reply(`Seed: ${seed}`);
   } catch (error: any) {
     const errorMessage = error.message || 'Unknown error';
     logger.error({ 

--- a/src/services/fal.ts
+++ b/src/services/fal.ts
@@ -1,5 +1,12 @@
 import { logger } from '../logger';
 
+export interface FalGenerationParams {
+  image_size?: string;
+  guidance_scale?: number;
+  num_inference_steps?: number;
+  num_images?: number;
+}
+
 interface FalGenerationResponse {
   seed: number;
   images: Array<{
@@ -15,6 +22,13 @@ interface FalGenerationResponse {
   has_nsfw_concepts: boolean[];
 }
 
+const DEFAULT_PARAMS: FalGenerationParams = {
+  image_size: 'landscape_4_3',
+  guidance_scale: 3.5,
+  num_inference_steps: 28,
+  num_images: 1
+};
+
 export class FalService {
   private readonly apiKey: string;
   private readonly apiSecret: string;
@@ -24,8 +38,23 @@ export class FalService {
     this.apiSecret = apiSecret;
   }
 
-  public async generateImage(prompt: string, negativePrompt?: string): Promise<string> {
+  public async generateImage(
+    prompt: string, 
+    negativePrompt?: string,
+    params: Partial<FalGenerationParams> = {}
+  ): Promise<string> {
     try {
+      const generationParams = {
+        ...DEFAULT_PARAMS,
+        ...params
+      };
+
+      logger.info({ 
+        prompt, 
+        negativePrompt, 
+        params: generationParams 
+      }, 'Generating image with parameters');
+
       const result = await fetch('https://queue.fal.run/fal-ai/flux-lora/subscribe', {
         method: 'POST',
         headers: {
@@ -36,10 +65,7 @@ export class FalService {
           input: {
             prompt,
             negative_prompt: negativePrompt,
-            image_size: 'landscape_4_3',
-            guidance_scale: 3.5,
-            num_inference_steps: 28,
-            num_images: 1
+            ...generationParams
           }
         }),
       });

--- a/src/services/generation.ts
+++ b/src/services/generation.ts
@@ -1,5 +1,5 @@
 import { fal } from '@fal-ai/client';
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Prisma } from '@prisma/client';
 import { config } from '../config.js';
 import { logger } from '../lib/logger.js';
 
@@ -28,6 +28,13 @@ interface FalRequest {
   num_images?: number;
 }
 
+interface GenerationParams {
+  image_size?: 'landscape_4_3' | 'portrait_4_3' | 'square';
+  num_inference_steps?: number;
+  guidance_scale?: number;
+  num_images?: number;
+}
+
 interface FalResponse {
   data: {
     images: Array<{
@@ -47,7 +54,7 @@ interface FalResponse {
 }
 
 // Default parameters if none are saved
-const DEFAULT_PARAMS = {
+const DEFAULT_PARAMS: GenerationParams = {
   image_size: 'landscape_4_3',
   num_inference_steps: 28,
   guidance_scale: 3.5,
@@ -75,8 +82,8 @@ export class GenerationService {
       }
 
       // Get user's saved parameters or use defaults
-      const userParams = user.parameters?.params || {};
-      const generationParams = {
+      const userParams = user.parameters?.params as GenerationParams || {};
+      const generationParams: GenerationParams = {
         ...DEFAULT_PARAMS,
         ...userParams,
       };

--- a/src/services/generation.ts
+++ b/src/services/generation.ts
@@ -1,5 +1,5 @@
 import { fal } from '@fal-ai/client';
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Prisma } from '@prisma/client';
 import { config } from '../config.js';
 import { logger } from '../lib/logger.js';
 
@@ -19,6 +19,16 @@ interface GenerationOptions {
 interface GenerationResult {
   imageUrl: string;
   seed: number;
+}
+
+interface UserParams {
+  image_size?: string;
+  num_inference_steps?: number;
+  guidance_scale?: number;
+  num_images?: number;
+  enable_safety_checker?: boolean;
+  output_format?: string;
+  [key: string]: any;
 }
 
 interface FalRequest {
@@ -75,7 +85,7 @@ export class GenerationService {
 
       try {
         // Get user parameters or use defaults
-        const userParams = user.parameters?.params || {};
+        const userParams = (user.parameters?.params || {}) as UserParams;
         const requestParams = {
           prompt,
           negative_prompt: negativePrompt,

--- a/src/services/generation.ts
+++ b/src/services/generation.ts
@@ -28,11 +28,22 @@ interface FalRequest {
   num_images?: number;
 }
 
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
 interface GenerationParams {
   image_size?: 'landscape_4_3' | 'portrait_4_3' | 'square';
   num_inference_steps?: number;
   guidance_scale?: number;
   num_images?: number;
+  [key: string]: JsonValue | undefined;
+}
+
+interface GenerationMetadata {
+  falRequestId: string;
+  inferenceTime?: number;
+  hasNsfw: boolean;
+  params: GenerationParams;
+  [key: string]: JsonValue | undefined;
 }
 
 interface FalResponse {
@@ -159,6 +170,13 @@ export class GenerationService {
 
         // Update database only if we have a valid image
         if (generatedImageUrl) {
+          const metadata: GenerationMetadata = {
+            falRequestId: falRequestId || '',
+            inferenceTime: response.data.timings?.inference,
+            hasNsfw: response.data.has_nsfw_concepts?.[0] || false,
+            params: generationParams
+          };
+          
           await prisma.user.update({
             where: { id: userId },
             data: {
@@ -171,12 +189,7 @@ export class GenerationService {
                   imageUrl: generatedImageUrl,
                   seed: seed ? BigInt(seed) : null,
                   starsUsed: 1,
-                  metadata: {
-                    falRequestId,
-                    inferenceTime: response.data.timings?.inference,
-                    hasNsfw: response.data.has_nsfw_concepts?.[0] || false,
-                    params: generationParams  // Save the parameters used
-                  }
+                  metadata: metadata as unknown as Prisma.InputJsonValue
                 }
               }
             }


### PR DESCRIPTION
This PR makes the FAL generation parameters configurable and adds logging to debug parameter issues:

1. Makes all generation parameters configurable through an optional params object
2. Adds default values that match the current hardcoded values
3. Adds logging of parameters during generation
4. Adds FalGenerationParams interface for type safety

To test:
1. Try generating with different image_size values
2. Verify num_images is respected
3. Check logs to see the actual parameters being used

The parameters from the miniapp should now be correctly used for generation.

Note: We need to make sure the bot is using these parameters when calling the service.