### PR TITLE
fix: use telegramId consistently for user identification

### DIFF
--- a/src/bot/commands/gen.ts
+++ b/src/bot/commands/gen.ts
@@ -19,10 +19,12 @@ composer.command('gen', async (ctx) => {
     return;
   }
 
+  const telegramId = ctx.from.id.toString();
+
   try {
     // Check user stars balance
     const user = await prisma.user.findUnique({
-      where: { telegramId: ctx.from.id.toString() }
+      where: { telegramId }
     });
     
     if (!user?.stars || user.stars < 1) {
@@ -32,7 +34,8 @@ composer.command('gen', async (ctx) => {
 
     await ctx.reply('🎨 Generating your image...');
 
-    const { imageUrl } = await GenerationService.generate(user.id, {
+    // Pass telegramId instead of user.id
+    const { imageUrl } = await GenerationService.generate(telegramId, {
       prompt,
     });
 
@@ -42,7 +45,7 @@ composer.command('gen', async (ctx) => {
     logger.error({ 
       error: errorMessage,
       prompt,
-      userId: ctx.from.id.toString()
+      userId: telegramId
     }, 'Generation command failed');
     await ctx.reply('Sorry, something went wrong while generating your image.');
   }

--- a/src/services/generation.ts
+++ b/src/services/generation.ts
@@ -46,13 +46,13 @@ interface FalResponse {
 }
 
 export class GenerationService {
-  static async generate(userId: string, options: GenerationOptions) {
+  static async generate(telegramId: string, options: GenerationOptions) {
     const { prompt, negativePrompt, loraPath, loraScale = 0.8, seed } = options;
 
     try {
-      // First check user's stars balance and get telegramId
+      // First check user's stars balance using telegramId
       const user = await prisma.user.findUnique({
-        where: { id: userId },
+        where: { telegramId },
         select: {
           id: true,
           stars: true,
@@ -131,7 +131,7 @@ export class GenerationService {
         // Update database only if we have a valid image
         if (generatedImageUrl) {
           await prisma.user.update({
-            where: { id: userId },
+            where: { telegramId },
             data: {
               stars: { decrement: 1 },
               generations: {
@@ -180,7 +180,7 @@ export class GenerationService {
       logger.error({ 
         error: errorMessage,
         prompt,
-        userId 
+        userId: telegramId
       }, 'Generation failed');
       throw new Error('Generation failed: ' + errorMessage);
     }


### PR DESCRIPTION
This PR fixes the "User not found" error by consistently using telegramId for user identification across the codebase.

Changes:
- Updated GenerationService to use telegramId instead of internal database id
- Updated gen command to pass telegramId to GenerationService
- Improved error messages to include correct user identifiers

This change makes user identification more reliable and consistent throughout the application.