### PR TITLE
Fix type errors in parameters route

### DIFF
--- a/src/server/routes/params.ts
+++ b/src/server/routes/params.ts
@@ -1,5 +1,6 @@
 import { FastifyPluginAsync } from 'fastify';
 import { prisma } from '../../lib/prisma.js';
+import { Prisma } from '@prisma/client';
 
 export const paramsRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.get('/parameters/:userId', async (request, reply) => {
@@ -36,6 +37,9 @@ export const paramsRoutes: FastifyPluginAsync = async (fastify) => {
       return reply.status(404).send({ error: 'User not found' });
     }
 
+    // Cast parameters to Prisma.JsonValue to ensure type compatibility
+    const jsonParams = parameters as Prisma.JsonValue;
+
     // Update or create parameters
     const updatedParams = await prisma.userParameters.upsert({
       where: {
@@ -43,10 +47,10 @@ export const paramsRoutes: FastifyPluginAsync = async (fastify) => {
       },
       create: {
         userId: userId,
-        params: parameters
+        params: jsonParams
       },
       update: {
-        params: parameters
+        params: jsonParams
       }
     });
 

--- a/src/server/routes/params.ts
+++ b/src/server/routes/params.ts
@@ -37,8 +37,8 @@ export const paramsRoutes: FastifyPluginAsync = async (fastify) => {
       return reply.status(404).send({ error: 'User not found' });
     }
 
-    // Cast parameters to Prisma.JsonValue to ensure type compatibility
-    const jsonParams = parameters as Prisma.JsonValue;
+    // Cast parameters to Prisma.InputJsonValue for database write operations
+    const jsonParams = parameters as Prisma.InputJsonValue;
 
     // Update or create parameters
     const updatedParams = await prisma.userParameters.upsert({


### PR DESCRIPTION
This PR fixes the TypeScript errors in the parameters route by:

1. Importing the Prisma types from @prisma/client
2. Properly casting parameters to Prisma.JsonValue to ensure type compatibility with the database schema

The changes resolve the build errors while maintaining the same functionality.