### PR TITLE
fix: use nullish coalescing for parameter fallbacks

### DIFF
--- a/src/services/generation.ts
+++ b/src/services/generation.ts
@@ -94,9 +94,9 @@ export class GenerationService {
           lora_path: loraPath,
           lora_scale: loraScale,
           seed,
-          image_size: (userParams?.image_size as 'landscape_4_3' | 'portrait_4_3' | 'square') || 'landscape_4_3',
-          num_inference_steps: userParams?.num_inference_steps || 28,
-          guidance_scale: userParams?.guidance_scale || 3.5,
+          image_size: (userParams?.image_size as 'landscape_4_3' | 'portrait_4_3' | 'square') ?? 'landscape_4_3',
+          num_inference_steps: userParams?.num_inference_steps ?? 28,
+          guidance_scale: userParams?.guidance_scale ?? 3.5,
         };
 
         // Log the final parameters being sent to FAL


### PR DESCRIPTION
This PR fixes an issue where user parameters were being overwritten by default values when they were falsy (like 0).

The problem was in the use of the OR operator (`||`) for fallback values, which would use the default value if the parameter was any falsy value (0, '', false). Changed to use nullish coalescing (`??`) so it only uses defaults when the parameter is null or undefined.

Changes:
- Updated parameter fallbacks in generation service to use `??` instead of `||`
- This ensures parameters like `guidance_scale: 7` are respected instead of falling back to defaults

Test plan:
1. Set parameters in miniapp (e.g. guidance_scale: 7)
2. Generate an image
3. Parameters should be used as set, without reverting to defaults