### PR TITLE
fix: load user parameters in generation command

### DIFF
--- a/src/bot/commands/gen.ts
+++ b/src/bot/commands/gen.ts
@@ -3,13 +3,36 @@ import { generateImage } from "../../services/generation.js";
 import { hasSubscription } from "../middlewares/subscription.js";
 import { handleError } from "../../utils/error.js";
 import { BotContext } from "../../types/bot.js";
+import { prisma } from "../../lib/prisma.js";
+import { logger } from "../../lib/logger.js";
 
 const composer = new Composer<BotContext>();
 
 composer.command("gen", hasSubscription, async (ctx) => {
   try {
+    // Get user parameters
+    const user = await prisma.user.findUnique({
+      where: { telegramId: ctx.from?.id.toString() },
+      include: { parameters: true }
+    });
+
+    // Extract parameters from user settings
+    const userParams = user?.parameters?.params;
+    logger.info({ 
+      userParams,
+      telegramId: ctx.from?.id
+    }, 'Loaded user parameters for generation');
+
     const response = await generateImage({
       prompt: ctx.message?.text?.replace(/^\/gen\s+/, "") || "",
+      // Map stored parameters to generation parameters
+      imageSize: userParams?.image_size,
+      numInferenceSteps: userParams?.num_inference_steps,
+      guidanceScale: userParams?.guidance_scale,
+      numImages: userParams?.num_images,
+      enableSafetyChecker: userParams?.enable_safety_checker,
+      outputFormat: userParams?.output_format as 'jpeg' | 'png' | undefined,
+      seed: userParams?.seed,
     });
 
     await ctx.replyWithPhoto(response.images[0].url);


### PR DESCRIPTION
This PR fixes the issue where user parameters weren't being loaded and applied during image generation.

Changes:
- Updated gen command to load user parameters from the database
- Pass user parameters to the generateImage function
- Added logging for parameter loading
- Maps database parameter names to the generation parameter names

Before this fix:
- User parameters were saved but not used in generation
- Default values were always used (guidance_scale: 3.5, num_inference_steps: 28)

After this fix:
- User's saved parameters are loaded and applied to each generation
- Default values are only used when parameters are not set

Test Plan:
1. Set parameters in miniapp (e.g., guidance_scale: 20, num_inference_steps: 50)
2. Run /gen command
3. Verify logs show parameters are loaded and applied
4. Verify generation uses the correct parameters