### PR TITLE
fix: load and apply saved user parameters during generation

### DIFF
--- a/src/bot/commands/gen.ts
+++ b/src/bot/commands/gen.ts
@@ -3,13 +3,36 @@ import { generateImage } from "../../services/generation.js";
 import { hasSubscription } from "../middlewares/subscription.js";
 import { handleError } from "../../utils/error.js";
 import { BotContext } from "../../types/bot.js";
+import { prisma } from "../../lib/prisma.js";
 
 const composer = new Composer<BotContext>();
 
 composer.command("gen", hasSubscription, async (ctx) => {
   try {
+    // Get user's saved parameters
+    const user = await prisma.user.findUnique({
+      where: { telegramId: ctx.from?.id.toString() },
+      include: { parameters: true }
+    });
+
+    // Extract generation parameters from user settings
+    const userParams = user?.parameters?.params as {
+      image_size?: string;
+      num_inference_steps?: number;
+      guidance_scale?: number;
+      num_images?: number;
+      enable_safety_checker?: boolean;
+      output_format?: string;
+    } | null;
+
     const response = await generateImage({
       prompt: ctx.message?.text?.replace(/^\/gen\s+/, "") || "",
+      imageSize: userParams?.image_size,
+      numInferenceSteps: userParams?.num_inference_steps,
+      guidanceScale: userParams?.guidance_scale,
+      numImages: userParams?.num_images,
+      enableSafetyChecker: userParams?.enable_safety_checker,
+      outputFormat: userParams?.output_format as 'jpeg' | 'png' | undefined,
     });
 
     await ctx.replyWithPhoto(response.images[0].url);


### PR DESCRIPTION
This PR fixes an issue where saved user parameters weren't being applied during image generation.

Changes:
- Load user's saved parameters from the database in the `/gen` command
- Pass all saved parameters to the `generateImage` function

Before this fix, the generation service was using default values even when user had custom parameters saved. Now it properly loads and applies the user's saved settings.

Test plan:
1. Save custom parameters in miniapp (e.g. guidance_scale: 20, steps: 50)
2. Use `/gen` command
3. Verify the generation uses the saved parameters instead of defaults

This fixes the parameter application issue where settings like `guidance_scale: 20` and `num_inference_steps: 50` weren't being applied to generations.