### PR TITLE
fix: Use correct LoRA path param and improve logging - ref19

### DIFF
--- a/src/types/generation.ts
+++ b/src/types/generation.ts
@@ -1,7 +1,7 @@
 export interface GenerateImageParams {
   prompt: string;
   loras?: {
-    weightsUrl: string;
+    path: string;  // Changed from weightsUrl to match the frontend
     scale: number;
   }[];
   imageSize?: string;


### PR DESCRIPTION
This PR fixes an issue where LoRA models were not being properly passed to FAL for image generation.

## Bug
When generating images with a LoRA model selected, the generation service was looking for a `weightsUrl` property on the LoRA parameter object, but the frontend was passing a `path` property. This caused the LoRA configuration to be lost when making requests to FAL.

## Changes
- Fixed LoRA parameter mapping to use the correct `path` property
- Replaced console.log statements with structured logger
- Added more detailed logging for debugging generation issues

## Testing
Previously:
```javascript
// Old code would try to access weightsUrl
path: lora.weightsUrl  // This was wrong
```

Now:
```javascript
// New code correctly uses path
path: lora.path  // This matches what frontend sends
```

## How to Test
1. Open the generate tab in miniapp
2. Select TOK Model LoRA
3. Set a scale value
4. Generate an image using the trigger word 'tok' in the prompt
5. Check logs to verify LoRA configuration is properly passed