### PR TITLE
fix: remove duplicate route registration code

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -32,23 +32,3 @@ export async function setupServer(app: FastifyInstance, bot: Bot<BotContext>) {
   const routes = app.printRoutes();
   logger.info({ routes }, 'Server routes configured');
 }
-
-  // Register API routes with explicit prefixes
-  await app.register(async function(fastify) {
-    // Bot webhook handler
-    fastify.post('/bot', webhookCallback(bot, 'fastify'));
-    
-    // API routes
-    await fastify.register(paramsRoutes, { prefix: '/api' });
-    await fastify.register(loraRoutes, { prefix: '/api' });
-
-    // Health check route
-    fastify.get('/health', async () => {
-      return { status: 'ok' };
-    });
-  });
-
-  // Log registered routes for debugging
-  const routes = app.printRoutes();
-  logger.info({ routes }, 'Server routes configured');
-}


### PR DESCRIPTION
This PR fixes the TypeScript build error in `src/server/index.ts` by removing the duplicate route registration code block.

### Changes
- Removed the duplicate route registration code block that was causing the TypeScript error
- Kept the original implementation intact
- No functionality changes, just code cleanup

### Testing
Please verify that:
1. The TypeScript build succeeds
2. All routes are working as expected
3. The bot webhook is functioning properly