### PR TITLE
fix: remove extra closing brace and duplicate code

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -32,23 +32,3 @@ export async function setupServer(app: FastifyInstance, bot: Bot<BotContext>) {
   const routes = app.printRoutes();
   logger.info({ routes }, 'Server routes configured');
 }
-
-  // Register API routes with explicit prefixes
-  await app.register(async function(fastify) {
-    // Bot webhook handler
-    fastify.post('/bot', webhookCallback(bot, 'fastify'));
-    
-    // API routes
-    await fastify.register(paramsRoutes, { prefix: '/api' });
-    await fastify.register(loraRoutes, { prefix: '/api' });
-
-    // Health check route
-    fastify.get('/health', async () => {
-      return { status: 'ok' };
-    });
-  });
-
-  // Log registered routes for debugging
-  const routes = app.printRoutes();
-  logger.info({ routes }, 'Server routes configured');
-}


### PR DESCRIPTION
This PR fixes the TypeScript build error in `src/server/index.ts` by properly removing:
1. The duplicate route registration code
2. The extra closing brace that was causing the TS1128 error

### Changes
- Removed duplicate code block
- Removed extra closing brace
- Kept only the necessary code structure

### Testing
1. The TypeScript build should now succeed without errors
2. Server functionality remains unchanged as this is just removing duplicated code