### PR TITLE
feat: add LoRA API routes

### DIFF
--- a/src/server/routes/loras.ts
+++ b/src/server/routes/loras.ts
@@ -1,9 +1,10 @@
 import { FastifyInstance } from 'fastify';
 import { prisma } from '../../lib/prisma.js';
 import { logger } from '../../lib/logger.js';
+import { validateTelegramWebAppData } from '../../lib/telegram.js';
 
 export async function loraRoutes(app: FastifyInstance) {
-  // Register GET /loras/available route
+  // Get available (public) LoRAs
   app.get('/loras/available', {
     schema: {
       response: {
@@ -24,8 +25,6 @@ export async function loraRoutes(app: FastifyInstance) {
     }
   }, async (request, reply) => {
     try {
-      logger.info('Receiving request for available LoRAs');
-      
       const loras = await prisma.loraModel.findMany({
         where: {
           status: 'COMPLETED',
@@ -43,11 +42,6 @@ export async function loraRoutes(app: FastifyInstance) {
         }
       });
       
-      logger.info({ 
-        count: loras.length,
-        loras: loras.map(l => ({id: l.databaseId, name: l.name}))
-      }, 'Fetched available LoRAs');
-      
       return loras;
     } catch (error) {
       logger.error({ error }, 'Failed to fetch available LoRAs');
@@ -55,6 +49,219 @@ export async function loraRoutes(app: FastifyInstance) {
     }
   });
 
-  // Log route registration
+  // Get user's LoRAs
+  app.get('/loras/user', {
+    schema: {
+      headers: {
+        type: 'object',
+        required: ['x-telegram-user-id', 'x-telegram-init-data'],
+        properties: {
+          'x-telegram-user-id': { type: 'string' },
+          'x-telegram-init-data': { type: 'string' }
+        }
+      },
+      response: {
+        200: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              databaseId: { type: 'string' },
+              name: { type: 'string' },
+              triggerWord: { type: 'string' },
+              status: { type: 'string' },
+              isPublic: { type: 'boolean' },
+              createdAt: { type: 'string' },
+              training: {
+                type: 'object',
+                properties: {
+                  steps: { type: 'number' },
+                  metadata: { type: 'object' }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }, async (request, reply) => {
+    try {
+      const initData = request.headers['x-telegram-init-data'] as string;
+      const telegramId = request.headers['x-telegram-user-id'] as string;
+
+      if (!initData || !validateTelegramWebAppData(initData)) {
+        return reply.status(401).send({ error: 'Invalid authentication' });
+      }
+
+      const user = await prisma.user.findUnique({
+        where: { telegramId },
+        select: { databaseId: true }
+      });
+
+      if (!user) {
+        return reply.status(404).send({ error: 'User not found' });
+      }
+
+      const loras = await prisma.loraModel.findMany({
+        where: {
+          userDatabaseId: user.databaseId
+        },
+        include: {
+          training: {
+            select: {
+              steps: true,
+              metadata: true
+            }
+          }
+        },
+        orderBy: {
+          createdAt: 'desc'
+        }
+      });
+
+      return loras;
+    } catch (error) {
+      logger.error({ error }, 'Failed to fetch user LoRAs');
+      reply.status(500).send({ error: 'Failed to fetch user LoRAs' });
+    }
+  });
+
+  // Toggle LoRA public status
+  app.post('/loras/:id/toggle-public', {
+    schema: {
+      headers: {
+        type: 'object',
+        required: ['x-telegram-user-id', 'x-telegram-init-data'],
+        properties: {
+          'x-telegram-user-id': { type: 'string' },
+          'x-telegram-init-data': { type: 'string' }
+        }
+      },
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: {
+          id: { type: 'string' }
+        }
+      },
+      body: {
+        type: 'object',
+        required: ['isPublic'],
+        properties: {
+          isPublic: { type: 'boolean' }
+        }
+      }
+    }
+  }, async (request, reply) => {
+    try {
+      const { id } = request.params as { id: string };
+      const { isPublic } = request.body as { isPublic: boolean };
+      const initData = request.headers['x-telegram-init-data'] as string;
+      const telegramId = request.headers['x-telegram-user-id'] as string;
+
+      if (!initData || !validateTelegramWebAppData(initData)) {
+        return reply.status(401).send({ error: 'Invalid authentication' });
+      }
+
+      const user = await prisma.user.findUnique({
+        where: { telegramId },
+        select: { databaseId: true }
+      });
+
+      if (!user) {
+        return reply.status(404).send({ error: 'User not found' });
+      }
+
+      const lora = await prisma.loraModel.findFirst({
+        where: {
+          databaseId: id,
+          userDatabaseId: user.databaseId
+        }
+      });
+
+      if (!lora) {
+        return reply.status(404).send({ error: 'LoRA not found or not owned by user' });
+      }
+
+      const updatedLora = await prisma.loraModel.update({
+        where: { databaseId: id },
+        data: { isPublic }
+      });
+
+      return updatedLora;
+    } catch (error) {
+      logger.error({ error }, 'Failed to toggle LoRA public status');
+      reply.status(500).send({ error: 'Failed to toggle LoRA public status' });
+    }
+  });
+
+  // Delete a LoRA
+  app.delete('/loras/:id', {
+    schema: {
+      headers: {
+        type: 'object',
+        required: ['x-telegram-user-id', 'x-telegram-init-data'],
+        properties: {
+          'x-telegram-user-id': { type: 'string' },
+          'x-telegram-init-data': { type: 'string' }
+        }
+      },
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: {
+          id: { type: 'string' }
+        }
+      }
+    }
+  }, async (request, reply) => {
+    try {
+      const { id } = request.params as { id: string };
+      const initData = request.headers['x-telegram-init-data'] as string;
+      const telegramId = request.headers['x-telegram-user-id'] as string;
+
+      if (!initData || !validateTelegramWebAppData(initData)) {
+        return reply.status(401).send({ error: 'Invalid authentication' });
+      }
+
+      const user = await prisma.user.findUnique({
+        where: { telegramId },
+        select: { databaseId: true }
+      });
+
+      if (!user) {
+        return reply.status(404).send({ error: 'User not found' });
+      }
+
+      const lora = await prisma.loraModel.findFirst({
+        where: {
+          databaseId: id,
+          userDatabaseId: user.databaseId
+        }
+      });
+
+      if (!lora) {
+        return reply.status(404).send({ error: 'LoRA not found or not owned by user' });
+      }
+
+      await prisma.$transaction(async (tx) => {
+        // Delete training first
+        await tx.training.deleteMany({
+          where: { loraId: id }
+        });
+
+        // Then delete the LoRA model
+        await tx.loraModel.delete({
+          where: { databaseId: id }
+        });
+      });
+
+      return { success: true };
+    } catch (error) {
+      logger.error({ error }, 'Failed to delete LoRA');
+      reply.status(500).send({ error: 'Failed to delete LoRA' });
+    }
+  });
+
   logger.info('LoRA routes registered');
 }


### PR DESCRIPTION
Adds required routes for ModelsTab:

- GET /loras/user - List user's models with training data
- POST /loras/:id/toggle-public - Toggle model visibility
- DELETE /loras/:id - Delete model and related training

All routes use Telegram WebApp auth and include Fastify schemas for validation.