### PR TITLE
feat: implement 150-star cost for training

### DIFF
--- a/src/server/routes/training.ts
+++ b/src/server/routes/training.ts
@@ -190,7 +190,7 @@ export async function trainingRoutes(app: FastifyInstance) {
               baseModel: { connect: { modelPath: 'fal-ai/flux-lora-fast-training' } },
               instancePrompt: params.trigger_word,
               steps: params.steps,
-              starsSpent: isTestMode ? 0 : 10,
+              starsSpent: isTestMode ? 0 : 150, // Set to training cost
               status: TrainStatus.PROCESSING,
               metadata
             }
@@ -225,6 +225,7 @@ export async function trainingRoutes(app: FastifyInstance) {
         }, 'Starting FAL training');
         
         const result = await trainingService.trainModel({
+          telegramId,
           images_data_url: zipUrl,
           trigger_word: params.trigger_word,
           steps: params.steps,


### PR DESCRIPTION
This PR implements the star deduction system for training, setting the cost at 150 stars per training.

### Changes:

1. Added Star Cost Management:
   - Defined training cost constant at 150 stars
   - Added star balance check before training starts
   - Implemented star deduction after successful training
   - Added transaction record with training metadata
   - Updated training record with stars spent

2. Enhanced Training Service:
   - Added telegramId to TrainModelParams interface
   - Added proper error handling for insufficient stars
   - Added logging for star-related operations
   - Added test mode bypass for star checks

### Implementation Details:
- Training costs 150 stars
- Stars are checked before training starts
- Stars are only deducted after successful training
- Transaction records include training details (trigger word, steps, etc.)
- Training record is updated with stars spent

### Testing Required:
1. Training with insufficient stars (should fail with clear message)
2. Training with exactly 150 stars (should succeed)
3. Training with more than 150 stars (should succeed)
4. Failed training should not deduct stars
5. Star transaction records should show proper metadata
6. Training records should show correct stars spent

### Note:
The frontend (selfi-miniapp-v2) will need to be updated to:
1. Check star balance before allowing training
2. Show proper error messages for insufficient stars
3. Update user interface to show training cost