### PR TITLE
feat: Add admin notifications for new users

### DIFF
--- a/src/bot/commands/start.ts
+++ b/src/bot/commands/start.ts
@@ -2,6 +2,7 @@ import { Composer } from 'grammy';
 import { BotContext } from '../../types/bot.js';
 import { getOrCreateUser } from '../../lib/user.js';
 import { logger } from '../../lib/logger.js';
+import { notifyNewUser } from '../../lib/admin.js';
 
 const composer = new Composer<BotContext>();
 
@@ -20,6 +21,11 @@ composer.command('start', async (ctx) => {
     
     const user = await getOrCreateUser(telegramId, ctx.from.username ?? undefined);
     logger.info({ telegramId, stars: user.stars }, 'User retrieved/created');
+    
+    // If this is a new user, notify admin
+    if (user.createdAt.getTime() === user.updatedAt.getTime()) {
+      await notifyNewUser(ctx.me, telegramId, ctx.from.username ?? undefined);
+    }
     
     const username = ctx.from.username ? `@${ctx.from.username}` : 'there';
     const message = `👋 Welcome ${username}!\n\nYou have ${user.stars} ⭐\n\n🌟 Here's what I can do for you:\n\n/gen - Generate a new image with AI\n/stars - Buy stars (currency for generations)\n/balance - Check your stars balance\n/help - Show all available commands\n\nEach image generation costs 1 star. Get started with the /stars command to purchase some stars!`;

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ const configSchema = z.object({
   // Telegram
   TELEGRAM_BOT_TOKEN: z.string(),
   TELEGRAM_PAYMENT_TOKEN: z.string().optional(),
+  ADMIN_TELEGRAM_ID: z.string(),
 
   // FAL AI
   FAL_KEY: z.string(),
@@ -39,6 +40,7 @@ const envConfig = {
   // Telegram
   TELEGRAM_BOT_TOKEN: process.env.TELEGRAM_BOT_TOKEN,
   TELEGRAM_PAYMENT_TOKEN: process.env.TELEGRAM_PAYMENT_TOKEN,
+  ADMIN_TELEGRAM_ID: process.env.ADMIN_TELEGRAM_ID,
 
   // FAL AI
   FAL_KEY: process.env.FAL_KEY,

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -1,0 +1,25 @@
+import { Bot } from 'grammy';
+import { BotContext } from '../types/bot.js';
+import { config } from '../config.js';
+import { logger } from './logger.js';
+
+export async function notifyAdmin(
+  bot: Bot<BotContext>,
+  message: string
+): Promise<void> {
+  try {
+    await bot.api.sendMessage(config.ADMIN_TELEGRAM_ID, message);
+    logger.info({ message }, 'Admin notification sent');
+  } catch (error) {
+    logger.error({ error, message }, 'Failed to send admin notification');
+  }
+}
+
+export async function notifyNewUser(
+  bot: Bot<BotContext>,
+  telegramId: string,
+  username?: string
+): Promise<void> {
+  const message = `🆕 New user started the bot!\n\nTelegram ID: ${telegramId}\nUsername: ${username ? '@' + username : 'Not provided'}`;
+  await notifyAdmin(bot, message);
+}


### PR DESCRIPTION
This PR implements admin notifications for new users starting the bot.

Changes:
1. Added ADMIN_TELEGRAM_ID to config
2. Created new admin notification utility
3. Updated start command to notify admin of new users

To use this feature:
1. Add ADMIN_TELEGRAM_ID to your environment variables with your Telegram ID
2. When a new user starts the bot, you'll receive a notification with their:
   - Telegram ID
   - Username (if available)

The notification system only triggers for new users (checking creation timestamp) to avoid duplicate notifications.