### PR TITLE
fix: prevent generation with empty prompt when clicking /gen command

### DIFF
--- a/src/bot/commands/gen.ts
+++ b/src/bot/commands/gen.ts
@@ -13,7 +13,16 @@ const lastProcessed = new Map<number, { msgId: number; timestamp: number }>();
 
 composer.command("gen", hasSubscription, async (ctx) => {
   // Ensure this is a text message with the command
-  if (!ctx.message?.text || !ctx.message.text.startsWith("/gen")) {
+  if (!ctx.message?.text) {
+    return;
+  }
+
+  // Extract prompt - everything after /gen
+  const prompt = ctx.message.text.split(/\/gen\s*/)[1]?.trim();
+  
+  // Check for empty or missing prompt
+  if (!prompt) {
+    await ctx.reply("❌ Please provide a prompt after the /gen command.\nExample: /gen a beautiful sunset");
     return;
   }
 
@@ -83,12 +92,6 @@ composer.command("gen", hasSubscription, async (ctx) => {
       output_format?: string;
       loras?: { path: string; scale: number }[];
     } | null;
-
-    const prompt = ctx.message.text.replace(/^\/gen\s+/, "").trim();
-    if (!prompt) {
-      await ctx.reply("Please provide a prompt after the /gen command.");
-      return;
-    }
 
     // Send a "processing" message
     const processingMsg = await ctx.reply("🎨 Generating your art...");


### PR DESCRIPTION
This PR fixes an issue where the /gen command would start a generation even with an empty prompt, which could lead to users accidentally using their stars.

Changes:
- Modified the prompt extraction to use a more strict split
- Moved the prompt check to the top of the function
- Added a more helpful error message with an example
- Prevents any generation from starting without a proper prompt

Test case:
1. Type or click `/gen` without any text
2. Bot should respond with an error message and example
3. No generation should start