### PR TITLE
fix: convert seed to BigInt for database storage

### DIFF
--- a/src/services/generation.ts
+++ b/src/services/generation.ts
@@ -155,8 +155,8 @@ export async function generateImage(params: GenerateImageParams & { telegramId: 
         loraScale: params.loras?.[0]?.scale
       };
 
-      // Convert the seed to BigInt string
-      const seedString = result.data.seed ? BigInt(result.data.seed).toString() : null;
+      // Convert the seed to BigInt
+      const seedValue = result.data.seed ? BigInt(result.data.seed) : null;
 
       const savedImage = await prisma.generation.create({
         data: {
@@ -165,7 +165,7 @@ export async function generateImage(params: GenerateImageParams & { telegramId: 
           loraId: firstLoraId,
           prompt: params.prompt,
           imageUrl: img.url,
-          seed: seedString,
+          seed: seedValue,
           starsUsed: requiredStars / numImages,
           metadata: metadata
         }


### PR DESCRIPTION
This PR fixes the Prisma validation error by converting the seed value directly to BigInt before saving to the database.

Changes:
- Modified `generateImage` function to convert seed to BigInt instead of string
- Ensures compatibility with PostgreSQL's bigint type

Fixes error: `Invalid value for argument 'seed': number too large to fit in target type`