### PR TITLE
feat: add LoRA details to generations response

### DIFF
--- a/src/server/routes/images.ts
+++ b/src/server/routes/images.ts
@@ -83,6 +83,8 @@ const imagesRoutes: FastifyPluginAsync = async (fastify) => {
           },
           loras: gen.lora ? [{
             path: gen.lora.databaseId,
+            name: gen.lora.name,
+            triggerWord: gen.lora.triggerWord,
             scale: (gen.metadata as Record<string, unknown> || {}).loraScale as number || 1
           }] : [],
         }));


### PR DESCRIPTION
Adds LoRA name and triggerWord to the generations API response to improve frontend display.