### PR TITLE
Hash-based seed compression

### DIFF
--- a/src/utils/seed.ts
+++ b/src/utils/seed.ts
@@ -1,0 +1,15 @@
+import { createHash } from 'crypto';
+
+export function compressLongSeed(seed: number): number {
+  const hash = createHash('md5')
+    .update(seed.toString())
+    .digest('hex');
+    
+  // Extract last 7 digits
+  const compressedSeed = parseInt(hash.slice(-7), 16) % 10000000;
+  return compressedSeed;
+}
+
+export function generateFalSeed(): number {
+  return Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
+}


### PR DESCRIPTION
This PR implements hash-based seed compression to improve user experience:

- Seeds are compressed to 7 digits using MD5 hash
- Original FAL seed is preserved in DB
- Frontend displays compressed seed in commands
- Backend handles conversion both ways