### PR TITLE
fix: handle admin ID type check properly

### DIFF
--- a/src/bot/commands/approve.ts
+++ b/src/bot/commands/approve.ts
@@ -13,8 +13,8 @@ composer.command('approve', async (ctx) => {
     return;
   }
 
-  // Check if command user is admin
-  if (ctx.from.id.toString() !== config.ADMIN_TELEGRAM_ID) {
+  // Check if admin ID is configured and if command user is admin
+  if (!config.ADMIN_TELEGRAM_ID || ctx.from.id.toString() !== config.ADMIN_TELEGRAM_ID.toString()) {
     logger.warn({
       telegramId: ctx.from.id.toString(),
       command: 'approve'


### PR DESCRIPTION
This PR fixes the type error in the approve command when checking admin ID.

### Changes
- Added null check for config.ADMIN_TELEGRAM_ID
- Convert both IDs to string before comparison to ensure type safety
- Added proper error handling for unconfigured admin ID

### Testing
1. Verify the bot builds without type errors
2. Test approve command still works for admin
3. Test approve command properly rejects non-admin users