### PR TITLE
feat: add privacy policy and command

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,65 @@
+# Selfi Bot Privacy Policy
+
+## 1. Introduction
+
+Selfi is a Telegram bot that allows users to generate AI images and train custom models. This privacy policy explains how we handle your data.
+
+## 2. Data Collection
+
+### 2.1 Basic Data
+- Telegram User ID
+- Username (if provided)
+- Transaction history related to stars
+- Generated images
+- Training data you provide
+
+### 2.2 Image Generation & Training
+- When you use /gen command, we store:
+  - The prompt used
+  - The generated image
+  - Stars used
+- When you train a custom model:
+  - Training images you provide
+  - Model parameters and settings
+  - Resulting model files
+
+## 3. Data Usage
+
+We use your data solely to:
+- Provide image generation services
+- Train and store your custom models
+- Manage your star balance
+- Maintain service functionality
+- Improve user experience
+
+## 4. Data Protection
+
+- We employ industry-standard security measures
+- Your data is not shared with third parties
+- Training images and models are stored securely
+- Only you can access your custom models
+
+## 5. Your Rights
+
+You can:
+- Request a copy of your data
+- Request deletion of your data
+- Revoke access at any time
+- Contact @lvc_io for support
+
+## 6. Data Retention
+
+- Generated images: stored for service functionality
+- Training data: retained while model is active
+- Transaction history: kept for service records
+- Account data: maintained while account is active
+
+## 7. Changes
+
+We may update this policy. Significant changes will be notified through the bot.
+
+## 8. Contact
+
+For privacy concerns, contact @lvc_io on Telegram.
+
+Last updated: February 13, 2025

--- a/src/bot/commands/index.ts
+++ b/src/bot/commands/index.ts
@@ -8,6 +8,7 @@ import helpCommand from './help.js';
 import grantCommand from './grant.js';
 import requestCommand from './request.js';
 import approveCommand from './approve.js';
+import privacyCommand from './privacy.js';
 import payments from '../payments/index.js';
 
 const composer = new Composer<BotContext>();
@@ -18,8 +19,9 @@ composer.use(genCommand);
 composer.use(balanceCommand);
 composer.use(helpCommand);
 composer.use(grantCommand);
-composer.use(requestCommand);  // Add request command
-composer.use(approveCommand);  // Add approve command
+composer.use(requestCommand);
+composer.use(approveCommand);
+composer.use(privacyCommand);
 composer.use(payments);
 
 export default composer;

--- a/src/bot/commands/privacy.ts
+++ b/src/bot/commands/privacy.ts
@@ -1,0 +1,31 @@
+import { Composer } from 'grammy';
+import { BotContext } from '../../types/bot.js';
+import { logger } from '../../lib/logger.js';
+
+const composer = new Composer<BotContext>();
+
+composer.command('privacy', async (ctx) => {
+  try {
+    const privacyText = `🔒 *Selfi Privacy Policy*
+
+We care about your privacy. Here's what you need to know:
+
+• We collect basic data like your Telegram ID and username
+• Generated images and prompts are stored for functionality
+• Training data is securely stored for your custom models
+• Your data is not shared with third parties
+• You can request data deletion anytime
+
+Full privacy policy: https://github.com/luc-io/selfi-bot-v2/blob/main/PRIVACY.md
+
+Questions? Contact @lvc_io`;
+
+    await ctx.reply(privacyText, { parse_mode: 'Markdown' });
+    logger.info({ command: 'privacy' }, 'Privacy policy sent');
+  } catch (error) {
+    logger.error({ error }, 'Failed to send privacy policy');
+    await ctx.reply('Sorry, something went wrong. Please try again later.');
+  }
+});
+
+export default composer;


### PR DESCRIPTION
This PR adds a privacy policy and related functionality to the bot.

### Changes
1. Added PRIVACY.md with detailed privacy policy
2. Added /privacy command to show privacy highlights
3. Updated command index to include privacy command

### Features
- Clear explanation of data collection and usage
- Focus on image generation and model training
- Easy access via /privacy command
- Link to full policy on GitHub

### Testing
1. Check that PRIVACY.md renders correctly
2. Test /privacy command - should show summary
3. Verify links in privacy command work