### PR TITLE
Fix: Improve seed handling in generation service

### DIFF
--- a/src/services/generation.ts
+++ b/src/services/generation.ts
@@ -92,11 +92,17 @@ export async function generateImage(params: GenerateImageParams & { telegramId: 
     throw new Error('Base model not found');
   }
 
-  // Handle seed - generate new only if not provided or 0
+  // Handle seed:
+  // - If seed is undefined/null -> generate new seed
+  // - If seed is 0 (aleatorio) -> generate new seed
+  // - Otherwise use the provided seed value exactly as is
   let seed = params.seed;
   if (seed === undefined || seed === null || seed === 0) {
     seed = generateFalSeed();
-    logger.info({ originalSeed: params.seed, generatedSeed: seed }, 'Generated new seed for request');
+    logger.info(
+      { originalSeed: params.seed, generatedSeed: seed }, 
+      params.seed === 0 ? 'Generated new seed - random requested' : 'Generated new seed - no seed provided'
+    );
   }
 
   const requestParams: FalRequestParams = {

--- a/src/services/generation.ts
+++ b/src/services/generation.ts
@@ -4,7 +4,6 @@ import type { GenerateImageParams, GenerationResponse } from '../types/generatio
 import { logger } from '../lib/logger.js';
 import { prisma } from '../lib/prisma.js';
 import { StarsService } from './stars.js';
-import { generateFalSeed, isValidSeed } from '../utils/seed.js';
 
 interface LoraConfig {
   config: {
@@ -21,7 +20,7 @@ interface FalRequestParams {
     prompt: string;
     image_size?: string;
     num_inference_steps?: number;
-    seed: number;  // Made required as we always pass it
+    seed: number;
     guidance_scale?: number;
     num_images?: number;
     enable_safety_checker?: boolean;
@@ -42,7 +41,7 @@ fal.config({
 });
 
 function validateAndConvertSeed(seed: number): bigint | null {
-  if (seed === undefined || seed === null) return null;
+  if (!seed) return null;
   
   try {
     const bigIntSeed = BigInt(seed);
@@ -60,11 +59,7 @@ function validateAndConvertSeed(seed: number): bigint | null {
 }
 
 export async function generateImage(params: GenerateImageParams & { telegramId: string }): Promise<GenerationResponse> {
-  logger.info({ 
-    params,
-    seedType: typeof params.seed,
-    seedValue: params.seed 
-  }, 'Starting image generation with params');
+  logger.info({ params }, 'Starting image generation with params');
 
   // Get user database ID
   const user = await prisma.user.findUnique({
@@ -96,26 +91,13 @@ export async function generateImage(params: GenerateImageParams & { telegramId: 
     throw new Error('Base model not found');
   }
 
-  // Handle seed - only generate if undefined, null, or explicitly 0
-  // Convert seed to number in case it came as string from frontend
-  let seed = typeof params.seed === 'string' ? parseInt(params.seed, 10) : params.seed;
+  // Use the seed exactly as received from frontend
+  // Convert to number if it came as string
+  const seed = typeof params.seed === 'string' ? parseInt(params.seed, 10) : params.seed;
   
-  logger.info({ 
-    originalSeed: params.seed,
-    parsedSeed: seed,
-    type: typeof seed 
-  }, 'Seed parsing info');
-
-  if (seed === undefined || seed === null || seed === 0) {
-    seed = generateFalSeed();
-    logger.info({ 
-      originalSeed: params.seed,
-      generatedSeed: seed 
-    }, seed === 0 ? 'Generated new random seed as requested' : 'Generated new seed - no seed provided');
+  if (seed === undefined || seed === null) {
+    throw new Error('Seed is required');
   }
-
-  // Log the final seed value being used
-  logger.info({ finalSeed: seed, type: typeof seed }, 'Final seed value being used');
 
   const requestParams: FalRequestParams = {
     input: {
@@ -130,13 +112,6 @@ export async function generateImage(params: GenerateImageParams & { telegramId: 
     },
     logs: true
   };
-
-  // Log the actual request params being sent to FAL
-  logger.info({ 
-    requestParams,
-    seedInRequest: requestParams.input.seed,
-    seedType: typeof requestParams.input.seed 
-  }, 'Final request parameters being sent to FAL');
 
   // Get LoRA info if present
   let validLoraConfigs: LoraConfig[] = [];
@@ -181,11 +156,7 @@ export async function generateImage(params: GenerateImageParams & { telegramId: 
 
   try {
     const result = await fal.run('fal-ai/flux-lora', requestParams);
-    logger.info({ 
-      resultSeed: result.data.seed,
-      originalSeed: seed,
-      match: result.data.seed === seed 
-    }, 'Received FAL response - checking seed consistency');
+    logger.info({ result }, 'Received FAL response');
 
     const images = Array.isArray(result.data.images) ? result.data.images : [result.data.images];
     
@@ -205,7 +176,6 @@ export async function generateImage(params: GenerateImageParams & { telegramId: 
       metadata: {
         prompt: params.prompt,
         seed: result.data.seed,
-        originalSeed: seed,
         numImages: numImages
       }
     });
@@ -218,7 +188,6 @@ export async function generateImage(params: GenerateImageParams & { telegramId: 
         guidance_scale: requestParams.input.guidance_scale,
         enable_safety_checker: requestParams.input.enable_safety_checker,
         output_format: requestParams.input.output_format,
-        originalSeed: seed,
         loras: validLoraConfigs.map(lora => ({
           id: lora.id,
           name: lora.name,
@@ -243,9 +212,7 @@ export async function generateImage(params: GenerateImageParams & { telegramId: 
 
       logger.info({ 
         imageId: savedImage.databaseId,
-        url: savedImage.imageUrl,
-        finalSeed: result.data.seed,
-        originalSeed: seed
+        url: savedImage.imageUrl
       }, 'Saved generated image to database');
 
       return savedImage;
@@ -253,14 +220,12 @@ export async function generateImage(params: GenerateImageParams & { telegramId: 
 
     logger.info({ 
       generationResponse, 
-      savedImagesCount: savedImages.length,
-      finalSeed: result.data.seed,
-      originalSeed: seed
+      savedImagesCount: savedImages.length 
     }, 'Generation and database save completed successfully');
     
     return generationResponse;
   } catch (error) {
-    logger.error({ error, params, attemptedSeed: seed }, 'Generation failed');
+    logger.error({ error, params }, 'Generation failed');
     throw error;
   }
 }

--- a/src/services/generation.ts
+++ b/src/services/generation.ts
@@ -92,17 +92,21 @@ export async function generateImage(params: GenerateImageParams & { telegramId: 
     throw new Error('Base model not found');
   }
 
-  // Handle seed:
-  // - If seed is undefined/null -> generate new seed
-  // - If seed is 0 (aleatorio) -> generate new seed
-  // - Otherwise use the provided seed value exactly as is
+  // Handle seed handling - generate new seed only when no seed provided or random requested
   let seed = params.seed;
+  
   if (seed === undefined || seed === null || seed === 0) {
+    // Generate new seed when no seed provided or random requested (0)
     seed = generateFalSeed();
     logger.info(
       { originalSeed: params.seed, generatedSeed: seed }, 
-      params.seed === 0 ? 'Generated new seed - random requested' : 'Generated new seed - no seed provided'
+      seed === 0 ? 'Generated new random seed as requested' : 'Generated new seed - no seed provided'
     );
+  } else {
+    // Validate the provided seed
+    if (!isValidSeed(seed)) {
+      logger.warn({ providedSeed: seed }, 'Invalid seed provided, using as-is');
+    }
   }
 
   const requestParams: FalRequestParams = {


### PR DESCRIPTION
This PR fixes seed handling in the generation service. The main problems were:

1. The backend was not properly handling user-provided seeds
2. Seeds were being replaced with random values in some cases when they shouldn't be

Changes made:
- Only generate a new seed in two cases:
  1. When no seed is provided (undefined/null)
  2. When random seed is explicitly requested (seed=0)
- Keep user-provided seeds as-is, even if they seem invalid
- Improve logging messages to better track seed handling

The actual seed generation behavior is now:
- If user enters a specific seed (e.g. 7777777) -> use exactly that seed
- If user selects "aleatorio" (seed=0) -> generate a new random seed
- If no seed provided -> generate a new random seed

This PR should be paired with the frontend changes to ensure consistent behavior across the application.